### PR TITLE
Bump major Soto version from 5 to 6

### DIFF
--- a/CODE/Package.resolved
+++ b/CODE/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "fc510a39cff61b849bf5cdff17eb2bd6d0777b49",
-        "version" : "1.11.5"
+        "revision" : "03b3e7b34153299e9b4c4b5c2a6ac790a582a3ac",
+        "version" : "1.12.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/soto-project/soto.git",
       "state" : {
-        "revision" : "3648a7fcbaa1ac06b6ab2b4b227d521ed065e780",
-        "version" : "5.13.1"
+        "revision" : "30bc0b8bdd5f096032b159d02784bef0da29a016",
+        "version" : "6.2.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/soto-project/soto-core.git",
       "state" : {
-        "revision" : "3079d17f2576cff5f2a3f68865629af455c673d1",
-        "version" : "5.9.3"
+        "revision" : "f8a8db612a6bca7a05f69e975464f7a841f43617",
+        "version" : "6.1.3"
       }
     },
     {
@@ -121,8 +121,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "bc4c55b9f9584f09eb971d67d956e28d08caa9d0",
-        "version" : "2.43.1"
+        "revision" : "edfceecba13d68c1c993382806e72f7e96feaa86",
+        "version" : "2.44.0"
       }
     },
     {
@@ -130,8 +130,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "6c84d247754ad77487a6f0694273b89b83efd056",
-        "version" : "1.14.0"
+        "revision" : "91dd2d61fb772e1311bb5f13b59266b579d77e42",
+        "version" : "1.15.0"
       }
     },
     {
@@ -139,8 +139,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "00576e6f1efa5c46dca2ca3081dc56dd233b402d",
-        "version" : "1.23.0"
+        "revision" : "d6656967f33ed8b368b38e4b198631fc7c484a40",
+        "version" : "1.23.1"
       }
     },
     {

--- a/CODE/Package.swift
+++ b/CODE/Package.swift
@@ -19,8 +19,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", revision: "98a23b64bb5feadf43eed2fc1edf08817d8449b4"),
         .package(url: "https://github.com/swift-server/swift-aws-lambda-events.git", branch: "main"),
-        .package(url: "https://github.com/soto-project/soto.git", from: "5.12.1"),
-        .package(url: "https://github.com/mahdibm/DiscordBM.git", from: "1.0.0-beta.11"),
+        .package(url: "https://github.com/soto-project/soto.git", from: "6.2.0"),
+        .package(url: "https://github.com/mahdibm/DiscordBM.git", from: "1.0.0-beta.14"),
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.9.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "3.0.0"),
         .package(url: "https://github.com/swift-server/swift-backtrace.git", from: "1.3.1")

--- a/CODE/Tests/Fake/TestData.swift
+++ b/CODE/Tests/Fake/TestData.swift
@@ -6,7 +6,7 @@ enum TestData {
         let currentDirectory = fileManager.currentDirectoryPath
         let path = currentDirectory + "/Tests/Resources/test_data.json"
         guard let data = fileManager.contents(atPath: path) else {
-            fatalError("Make sure you've set the custom working directory for the 'PennyBOT' scheme: https://docs.vapor.codes/getting-started/xcode/#custom-working-directory")
+            fatalError("Make sure you've set the custom working directory for the current scheme: https://docs.vapor.codes/getting-started/xcode/#custom-working-directory")
         }
         let object = try! JSONSerialization.jsonObject(with: data, options: [])
         return object as! [String: Any]


### PR DESCRIPTION
This will bump Penny's Soto version from 5 to 6.
_I think_ we can also finally update to AHC 1.12.0 and hope it doesn't conflict with Soto/AWS stuff. Saw a fix related to it somewhere, but can't find a link to it anymore.