### PR TITLE
Introducing `BotStateManager` to avoid duplicate answers by Penny on startup

### DIFF
--- a/CODE/Package.swift
+++ b/CODE/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "PennyAPI",
     platforms: [
-        .macOS(.v12)
+        .macOS(.v13)
     ],
     products: [
         .executable(name: "PennyLambdaAddCoins", targets: ["PennyLambdaAddCoins"]),

--- a/CODE/Sources/PennyBOT/BotFactory.swift
+++ b/CODE/Sources/PennyBOT/BotFactory.swift
@@ -6,8 +6,7 @@ import Foundation
 enum BotFactory {
     static var makeBot: (any EventLoopGroup, HTTPClient) -> any GatewayManager = {
         eventLoopGroup, client in
-        guard let token = ProcessInfo.processInfo.environment["BOT_TOKEN"],
-              let appId = ProcessInfo.processInfo.environment["BOT_APP_ID"] else {
+        guard let token = Constants.botToken, let appId = Constants.botId else {
             fatalError("Missing 'BOT_TOKEN' or 'BOT_APP_ID' env vars")
         }
         return BotGatewayManager(

--- a/CODE/Sources/PennyBOT/Constants.swift
+++ b/CODE/Sources/PennyBOT/Constants.swift
@@ -1,5 +1,8 @@
 import Foundation
 
 enum Constants {
+    static let internalChannelId = "441327731486097429"
+    static var botToken: String! = ProcessInfo.processInfo.environment["BOT_TOKEN"]
+    static var botId: String! = ProcessInfo.processInfo.environment["BOT_APP_ID"]
     static var coinServiceBaseUrl: String! = ProcessInfo.processInfo.environment["API_BASE_URL"]
 }

--- a/CODE/Sources/PennyBOT/Handlers/BotStateManager.swift
+++ b/CODE/Sources/PennyBOT/Handlers/BotStateManager.swift
@@ -77,7 +77,7 @@ actor BotStateManager {
         }
     }
     
-    #if DEBUG
+#if DEBUG
     func tests_reset() {
         BotStateManager.shared = BotStateManager()
     }
@@ -85,5 +85,5 @@ actor BotStateManager {
     func tests_setDisableDuration(to duration: Duration) {
         self.disableDuration = duration
     }
-    #endif
+#endif
 }

--- a/CODE/Sources/PennyBOT/Handlers/BotStateManager.swift
+++ b/CODE/Sources/PennyBOT/Handlers/BotStateManager.swift
@@ -17,7 +17,7 @@ actor BotStateManager {
     let id = Date().timeIntervalSince1970
     
     let signal = "Hello the other Pennys 👋 you can retire now :)"
-    let disableTime = Duration.seconds(3 * 60)
+    var disableDuration = Duration.seconds(3 * 60)
     
     static private(set) var shared = BotStateManager()
     
@@ -49,7 +49,7 @@ actor BotStateManager {
         logger.warning("Received shutdown signal from another Penny")
         self.canRespond = false
         Task {
-            try await Task.sleep(for: disableTime)
+            try await Task.sleep(for: disableDuration)
             self.canRespond = true
             await send(content: "Wow! Why am I still alive?! I thought I should be retired by now!\nOn a real note though, **THIS IS AN ERROR. INVESTIGATE THE SITUATION**")
             logger.error("AWS has not yet shutdown this instance of Penny! Why?!")
@@ -80,6 +80,10 @@ actor BotStateManager {
     #if DEBUG
     func tests_reset() {
         BotStateManager.shared = BotStateManager()
+    }
+    
+    func tests_setDisableDuration(to duration: Duration) {
+        self.disableDuration = duration
     }
     #endif
 }

--- a/CODE/Sources/PennyBOT/Handlers/BotStateManager.swift
+++ b/CODE/Sources/PennyBOT/Handlers/BotStateManager.swift
@@ -3,10 +3,11 @@ import Foundation
 import Logging
 
 /*
- When we update the bot, AWS waits a few minutes before taking down the old Penny instance.
+ When we update Penny, AWS waits a few minutes before taking down the old Penny instance to
+ make sure the new instance is healthy.
  This makes it so there is a short period where there are 2 Penny bots that will respond to
  Discord Gateway events.
- This Handler's job is to prevent that. Only the new bot should respond to events.
+ This actor's job is to prevent that. Only the new bot should respond to events.
  */
 actor BotStateManager {
     
@@ -16,7 +17,7 @@ actor BotStateManager {
     let id = Date().timeIntervalSince1970
     
     let signal = "Hello the other Pennys 👋 you can retire now :)"
-    let disableTime = Duration.seconds(4 * 60)
+    let disableTime = Duration.seconds(3 * 60)
     
     static private(set) var shared = BotStateManager()
     

--- a/CODE/Sources/PennyBOT/Handlers/BotStateManager.swift
+++ b/CODE/Sources/PennyBOT/Handlers/BotStateManager.swift
@@ -1,0 +1,84 @@
+import DiscordBM
+import Foundation
+import Logging
+
+/*
+ When we update the bot, AWS waits a few minutes before taking down the old Penny instance.
+ This makes it so there is a short period where there are 2 Penny bots that will respond to
+ Discord Gateway events.
+ This Handler's job is to prevent that. Only the new bot should respond to events.
+ */
+actor BotStateManager {
+    
+    var discordClient: (any DiscordClient)!
+    var logger: Logger!
+    var canRespond = true
+    let id = Date().timeIntervalSince1970
+    
+    let signal = "Hello the other Pennys 👋 you can retire now :)"
+    let disableTime = Duration.seconds(4 * 60)
+    
+    static private(set) var shared = BotStateManager()
+    
+    private init() { }
+    
+    func initialize(discordClient: any DiscordClient, logger: Logger) {
+        self.discordClient = discordClient
+        self.logger = logger
+        Task { await send(content: signal) }
+    }
+    
+    func canRespond(to event: Gateway.Event) -> Bool {
+        checkIfItsASlowdownSignal(event: event)
+        return canRespond
+    }
+    
+    private func checkIfItsASlowdownSignal(event: Gateway.Event) {
+        guard case let .messageCreate(message) = event.data,
+              message.channel_id == Constants.internalChannelId,
+              let author = message.author,
+              author.id == Constants.botId,
+              message.content.hasPrefix(signal)
+        else { return }
+        guard let otherId = message.content.split(whereSeparator: \.isNewline).last else {
+            logger.warning("Can't find id of the other Penny")
+            return
+        }
+        guard otherId != "\(self.id)" else { return }
+        logger.warning("Received shutdown signal from another Penny")
+        self.canRespond = false
+        Task {
+            try await Task.sleep(for: disableTime)
+            self.canRespond = true
+            await send(content: "Wow! Why am I still alive?! I thought I should be retired by now!\nOn a real note though, **THIS IS AN ERROR. INVESTIGATE THE SITUATION**")
+            logger.error("AWS has not yet shutdown this instance of Penny! Why?!")
+        }
+        Task {
+            await send(content: "Ok the new Penny! I'll retire myself for a few minutes :)")
+        }
+    }
+    
+    private func send(content: String) async {
+        // The DiscordClient will retry the request too in some situations,
+        // so we shouldn't need to retry it ourselves.
+        do {
+            let response = try await discordClient.createMessage(
+                channelId: Constants.internalChannelId,
+                payload: .init(content: content + "\n\(self.id)")
+            )
+            if (200..<300).contains(response.httpResponse.status.code) {
+                logger.debug("BotStateManager failed to send a message")
+            } else {
+                logger.error("BotStateManager received non-200 status code. Response: \(response)")
+            }
+        } catch {
+            logger.error("BotStateManager received error: \(error)")
+        }
+    }
+    
+    #if DEBUG
+    func tests_reset() {
+        BotStateManager.shared = BotStateManager()
+    }
+    #endif
+}

--- a/CODE/Sources/PennyBOT/Handlers/EventHandler.swift
+++ b/CODE/Sources/PennyBOT/Handlers/EventHandler.swift
@@ -9,6 +9,12 @@ struct EventHandler {
     
     func handle() {
         Task {
+            guard await BotStateManager.shared.canRespond(to: event) else {
+                logger.debug("BotStateManager doesn't allow responding to event", metadata: [
+                    "event": "\(event)"
+                ])
+                return
+            }
             switch event.data {
             case .messageCreate(let message):
                 await MessageHandler(

--- a/CODE/Sources/PennyBOT/Penny.swift
+++ b/CODE/Sources/PennyBOT/Penny.swift
@@ -31,6 +31,8 @@ struct Penny {
         let bot = BotFactory.makeBot(eventLoopGroup, client)
         
         Task {
+            await BotStateManager.shared.initialize(discordClient: bot.client, logger: logger)
+            
             await bot.addEventHandler { event in
                 EventHandler(
                     event: event,

--- a/CODE/Tests/Fake/FakeCoinLambdaHandler.swift
+++ b/CODE/Tests/Fake/FakeCoinLambdaHandler.swift
@@ -14,7 +14,7 @@ public struct FakeCoinLambdaHandler: LambdaHandler {
     let userService: UserService
     
     public init(context: LambdaInitializationContext) async throws {
-        // The `client` won't be used at all, but still needs to be passed to user service
+        // The 'client' won't be used at all, but still needs to be passed to user service
         let client = AWSClient(httpClientProvider: .createNew)
         self.userService = .init(client, Logger(label: "Test_UserService"))
         context.terminator.register(name: "Shut Down") { eventLoop in

--- a/CODE/Tests/Fake/FakeManager.swift
+++ b/CODE/Tests/Fake/FakeManager.swift
@@ -14,11 +14,9 @@ public actor FakeManager: GatewayManager {
     
     public init() { }
     
-    public nonisolated func connect() {
-        Task {
-            self._state.store(.connected, ordering: .relaxed)
-            await connectionWaiter?.resume()
-        }
+    public func connect() {
+        self._state.store(.connected, ordering: .relaxed)
+        connectionWaiter?.resume()
     }
     public func requestGuildMembersChunk(payload: Gateway.RequestGuildMembers) async { }
     public func addEventHandler(_ handler: @escaping (Gateway.Event) -> Void) async {
@@ -27,7 +25,7 @@ public actor FakeManager: GatewayManager {
     public func addEventParseFailureHandler(
         _ handler: @escaping (Error, String) -> Void
     ) async { }
-    public nonisolated func disconnect() { }
+    public func disconnect() { }
     
     var connectionWaiter: CheckedContinuation<(), Never>?
     
@@ -41,7 +39,7 @@ public actor FakeManager: GatewayManager {
         }
     }
     
-    public func send(key: EventKey) throws {
+    func send(key: EventKey) throws {
         let data = TestData.for(key: key.rawValue)!
         let decoder = JSONDecoder()
         let event = try decoder.decode(Gateway.Event.self, from: data)
@@ -70,16 +68,19 @@ public enum EventKey: String {
     case thanksMessage
     case linkInteraction
     case thanksReaction
+    case stopRespondingToMessages
     
     /// The endpoints from which the bot will send a response, after receiving each event.
     var responseEndpoints: [Endpoint] {
         switch self {
         case .thanksMessage:
-            return [.postCreateMessage(channelId: "441327731486097429")]
+            return [.postCreateMessage(channelId: "1016614538398937098")]
         case .linkInteraction:
             return [.editOriginalInteractionResponse(appId: "11111111", token: "aW50ZXJhY3Rpb246MTAzMTExMjExMzk3ODA4OTUwMjpRVGVBVXU3Vk1XZ1R0QXpiYmhXbkpLcnFqN01MOXQ4T2pkcGRXYzRjUFNMZE9TQ3g4R3NyM1d3OGszalZGV2c3a0JJb2ZTZnluS3VlbUNBRDh5N2U3Rm00QzQ2SWRDMGJrelJtTFlveFI3S0RGbHBrZnpoWXJSNU1BV1RqYk5Xaw"), .createInteractionResponse(id: "1031112113978089502", token: "aW50ZXJhY3Rpb246MTAzMTExMjExMzk3ODA4OTUwMjpRVGVBVXU3Vk1XZ1R0QXpiYmhXbkpLcnFqN01MOXQ4T2pkcGRXYzRjUFNMZE9TQ3g4R3NyM1d3OGszalZGV2c3a0JJb2ZTZnluS3VlbUNBRDh5N2U3Rm00QzQ2SWRDMGJrelJtTFlveFI3S0RGbHBrZnpoWXJSNU1BV1RqYk5Xaw")]
         case .thanksReaction:
             return [.postCreateMessage(channelId: "966722151359057950")]
+        case .stopRespondingToMessages:
+            return [.postCreateMessage(channelId: "441327731486097429")]
         }
     }
 }

--- a/CODE/Tests/Resources/test_data.json
+++ b/CODE/Tests/Resources/test_data.json
@@ -58,7 +58,7 @@
             "edited_timestamp": null,
             "content": "<@950695294906007573> thank you :\\) nice job!",
             "components": [],
-            "channel_id": "441327731486097429",
+            "channel_id": "1016614538398937098",
             "author": {
                 "username": "Mahdi BM",
                 "public_flags": 0,
@@ -197,5 +197,50 @@
         "edited_timestamp": null,
         "flags": 0,
         "components": []
+    },
+    "stopRespondingToMessages": {
+        "t": "MESSAGE_CREATE",
+        "s": 4,
+        "op": 0,
+        "d": {
+            "type": 0,
+            "tts": false,
+            "timestamp": "2022-11-04T07:53:19.920000+00:00",
+            "referenced_message": null,
+            "pinned": false,
+            "mentions": [],
+            "mention_roles": [],
+            "mention_everyone": false,
+            "member": {
+                "roles": [],
+                "premium_since": null,
+                "pending": false,
+                "nick": null,
+                "mute": false,
+                "joined_at": "2022-09-11T14:26:19.569000+00:00",
+                "flags": 0,
+                "deaf": false,
+                "communication_disabled_until": null,
+                "avatar": null
+            },
+            "id": "1037997964976726088",
+            "flags": 0,
+            "embeds": [],
+            "edited_timestamp": null,
+            "content": "Hello the other Pennys 👋 you can retire now :)\n1667554166.92193",
+            "components": [],
+            "channel_id": "441327731486097429",
+            "author": {
+                "username": "TestApp",
+                "public_flags": 0,
+                "id": "1016612301262041098",
+                "discriminator": "7843",
+                "bot": true,
+                "avatar_decoration": null,
+                "avatar": null
+            },
+            "attachments": [],
+            "guild_id": "808638139785936919"
+        }
     }
 }


### PR DESCRIPTION
### Problem
When we update Penny, AWS waits a few minutes before taking down the old Penny instance to make sure the new instance is healthy.
This makes it so there is a short period where there are 2 Penny bots that will respond to Discord Gateway events.
Only the new bot should respond to events.

### Solution
This PR introduces a new `BotStateManager` actor.
On initialization, this actor sends a message to an internal channel in Discord that Penny has access to, and asks the other Pennys to stop responding to new gateway events.
The old Pennys upon receiving this message, will stop responding to gateway events for the next 3 minutes.
If the new instance is healthy, AWS will shutdown the old instance after 1-2-3 minutes. Otherwise the old instance will start processing Gateway events again after those 3 minutes, and the bot won't be disabled.

Other than having some tests, I've also manually tested this PR.