### PR TITLE
Temporarily don't use `HTTPClient.shared` in `GitHubAPI`

### DIFF
--- a/Lambdas/GitHubAPI/+Client.swift
+++ b/Lambdas/GitHubAPI/+Client.swift
@@ -14,7 +14,11 @@ extension Client {
         )
         let transport = AsyncHTTPClientTransport(
             configuration: .init(
-                client: HTTPClient.shared,
+                client: HTTPClient(
+                    configuration: .init(
+                        decompression: .enabled(limit: .ratio(20))
+                    )
+                ),
                 timeout: timeout
             )
         )


### PR DESCRIPTION
https://github.com/swift-server/async-http-client/issues/739