### PR TITLE
Fix fetch-contributors logic to thank new contributors

### DIFF
--- a/Lambdas/GHHooks/EventHandler/Handlers/ReleaseMaker.swift
+++ b/Lambdas/GHHooks/EventHandler/Handlers/ReleaseMaker.swift
@@ -331,13 +331,13 @@ struct ReleaseMaker {
 
         if case let .ok(ok) = response,
            case let .json(json) = ok.body {
-            logger.debug("Found some contributors", metadata: [
+            logger.debug("Fetched some contributors", metadata: [
                 "page": .stringConvertible(page),
                 "count": .stringConvertible(json.compactMap(\.id).count)
             ])
             return json
         } else {
-            logger.warning("Could not find more contributors", metadata: [
+            logger.warning("Error when fetching contributors", metadata: [
                 "page": .stringConvertible(page),
                 "response": "\(response)"
             ])

--- a/Lambdas/GHHooks/EventHandler/Handlers/ReleaseMaker.swift
+++ b/Lambdas/GHHooks/EventHandler/Handlers/ReleaseMaker.swift
@@ -332,6 +332,8 @@ struct ReleaseMaker {
 
         if case let .ok(ok) = response,
            case let .json(json) = ok.body {
+            /// Example of a `link` header: `<https://api.github.com/repositories/49910095/contributors?page=6>; rel="prev", <https://api.github.com/repositories/49910095/contributors?page=8>; rel="next", <https://api.github.com/repositories/49910095/contributors?page=8>; rel="last", <https://api.github.com/repositories/49910095/contributors?page=1>; rel="first"`
+            /// If the header contains `rel="next"` then we'll have a next page to fetch.
             let hasNext = switch ok.headers.Link {
             case let .case1(string):
                 string.contains(#"rel="next""#)

--- a/Lambdas/GHHooks/EventHandler/Handlers/ReleaseMaker.swift
+++ b/Lambdas/GHHooks/EventHandler/Handlers/ReleaseMaker.swift
@@ -303,7 +303,11 @@ struct ReleaseMaker {
         /// to reserve enough capacity for it up-front.
         contributorIds.reserveCapacity(250)
         while let contributors = try await self.getExistingContributorIDs(page: page) {
-            contributorIds.append(contentsOf: contributors.compactMap(\.id))
+            let ids = (consume contributors).compactMap(\.id)
+            if ids.isEmpty {
+                break
+            }
+            contributorIds.append(contentsOf: consume ids)
             page += 1
         }
         return Set(contributorIds)


### PR DESCRIPTION
Apparently it only fetched first 30?! not sure if GitHub recently changed this or not.