### PR TITLE
Revert usage of `HTTPClient.shared`

### DIFF
--- a/Lambdas/AutoFaqs/AutoFaqsHandler.swift
+++ b/Lambdas/AutoFaqs/AutoFaqsHandler.swift
@@ -1,8 +1,10 @@
 import AWSLambdaRuntime
 import AWSLambdaEvents
+import AsyncHTTPClient
 import Foundation
 import SotoCore
 import Models
+import Shared
 import LambdasShared
 
 @main
@@ -14,11 +16,12 @@ struct AutoFaqsHandler: LambdaHandler {
     let autoFaqsRepo: S3AutoFaqsRepository
 
     init(context: LambdaInitializationContext) async {
-        let awsClient = AWSClient(
-            httpClientProvider: .createNewWithEventLoopGroup(context.eventLoop)
+        let httpClient = HTTPClient(
+            eventLoopGroupProvider: .shared(context.eventLoop),
+            configuration: .forPenny
         )
-        self.awsClient = awsClient
-        self.autoFaqsRepo = S3AutoFaqsRepository(awsClient: awsClient, logger: context.logger)
+        self.awsClient = AWSClient(httpClient: httpClient)
+        self.autoFaqsRepo = S3AutoFaqsRepository(awsClient: self.awsClient, logger: context.logger)
     }
 
     func handle(

--- a/Lambdas/AutoFaqs/AutoFaqsHandler.swift
+++ b/Lambdas/AutoFaqs/AutoFaqsHandler.swift
@@ -14,7 +14,10 @@ struct AutoFaqsHandler: LambdaHandler {
     let autoFaqsRepo: S3AutoFaqsRepository
 
     init(context: LambdaInitializationContext) async {
-        self.awsClient = AWSClient()
+        let awsClient = AWSClient(
+            httpClientProvider: .createNewWithEventLoopGroup(context.eventLoop)
+        )
+        self.awsClient = awsClient
         self.autoFaqsRepo = S3AutoFaqsRepository(awsClient: awsClient, logger: context.logger)
     }
 

--- a/Lambdas/AutoPings/AutoPingsHandler.swift
+++ b/Lambdas/AutoPings/AutoPingsHandler.swift
@@ -1,8 +1,10 @@
 import AWSLambdaRuntime
 import AWSLambdaEvents
+import AsyncHTTPClient
 import Foundation
 import SotoCore
 import Models
+import Shared
 import LambdasShared
 
 @main
@@ -14,11 +16,12 @@ struct AutoPingsHandler: LambdaHandler {
     let pingsRepo: S3AutoPingsRepository
 
     init(context: LambdaInitializationContext) async {
-        let awsClient = AWSClient(
-            httpClientProvider: .createNewWithEventLoopGroup(context.eventLoop)
+        let httpClient = HTTPClient(
+            eventLoopGroupProvider: .shared(context.eventLoop),
+            configuration: .forPenny
         )
-        self.awsClient = awsClient
-        self.pingsRepo = S3AutoPingsRepository(awsClient: awsClient, logger: context.logger)
+        self.awsClient = AWSClient(httpClient: httpClient)
+        self.pingsRepo = S3AutoPingsRepository(awsClient: self.awsClient, logger: context.logger)
     }
     
     func handle(

--- a/Lambdas/AutoPings/AutoPingsHandler.swift
+++ b/Lambdas/AutoPings/AutoPingsHandler.swift
@@ -14,7 +14,10 @@ struct AutoPingsHandler: LambdaHandler {
     let pingsRepo: S3AutoPingsRepository
 
     init(context: LambdaInitializationContext) async {
-        self.awsClient = AWSClient()
+        let awsClient = AWSClient(
+            httpClientProvider: .createNewWithEventLoopGroup(context.eventLoop)
+        )
+        self.awsClient = awsClient
         self.pingsRepo = S3AutoPingsRepository(awsClient: awsClient, logger: context.logger)
     }
     

--- a/Lambdas/Faqs/FaqsHandler.swift
+++ b/Lambdas/Faqs/FaqsHandler.swift
@@ -1,5 +1,6 @@
 import AWSLambdaRuntime
 import AWSLambdaEvents
+import AsyncHTTPClient
 import Foundation
 import SotoCore
 import Models
@@ -14,9 +15,11 @@ struct FaqsHandler: LambdaHandler {
     let faqsRepo: S3FaqsRepository
 
     init(context: LambdaInitializationContext) async {
-        let awsClient = AWSClient(
-            httpClientProvider: .createNewWithEventLoopGroup(context.eventLoop)
+        let httpClient = HTTPClient(
+            eventLoopGroupProvider: .shared(context.eventLoop),
+            configuration: .forPenny
         )
+        let awsClient = AWSClient(httpClient: httpClient)
         self.awsClient = awsClient
         self.faqsRepo = S3FaqsRepository(awsClient: awsClient, logger: context.logger)
     }

--- a/Lambdas/Faqs/FaqsHandler.swift
+++ b/Lambdas/Faqs/FaqsHandler.swift
@@ -14,7 +14,10 @@ struct FaqsHandler: LambdaHandler {
     let faqsRepo: S3FaqsRepository
 
     init(context: LambdaInitializationContext) async {
-        self.awsClient = AWSClient()
+        let awsClient = AWSClient(
+            httpClientProvider: .createNewWithEventLoopGroup(context.eventLoop)
+        )
+        self.awsClient = awsClient
         self.faqsRepo = S3FaqsRepository(awsClient: awsClient, logger: context.logger)
     }
 

--- a/Lambdas/GHHooks/+Rendering/+LeafRenderer.swift
+++ b/Lambdas/GHHooks/+Rendering/+LeafRenderer.swift
@@ -5,11 +5,16 @@ import Logging
 import Foundation
 
 extension LeafRenderer {
-    static func forGHHooks(logger: Logger) throws -> LeafRenderer {
+    static func forGHHooks(httpClient: HTTPClient, logger: Logger) throws -> LeafRenderer {
         try LeafRenderer(
             subDirectory: "GHHooksLambda",
-            extraSources: [DocsLeafSource(logger: logger)],
-            logger: logger
+            httpClient: httpClient,
+            extraSources: [DocsLeafSource(
+                httpClient: httpClient,
+                logger: logger
+            )],
+            logger: logger,
+            on: httpClient.eventLoopGroup.next()
         )
     }
 }
@@ -39,7 +44,7 @@ private struct DocsLeafSource: LeafSource {
         }
     }
 
-    let httpClient: HTTPClient = .shared
+    let httpClient: HTTPClient
     let logger: Logger
 
     func file(

--- a/Lambdas/GHHooks/Authenticator.swift
+++ b/Lambdas/GHHooks/Authenticator.swift
@@ -10,7 +10,7 @@ import Shared
 
 actor Authenticator {
     private let secretsRetriever: SecretsRetriever
-    private let httpClient: HTTPClient = .shared
+    private let httpClient: HTTPClient
     let logger: Logger
 
     /// The cached access token.
@@ -18,8 +18,9 @@ actor Authenticator {
 
     private let queue = SerialProcessor()
 
-    init(secretsRetriever: SecretsRetriever, logger: Logger) {
+    init(secretsRetriever: SecretsRetriever, httpClient: HTTPClient, logger: Logger) {
         self.secretsRetriever = secretsRetriever
+        self.httpClient = httpClient
         self.logger = logger
     }
 
@@ -60,6 +61,7 @@ actor Authenticator {
 
     private func makeClient(token: String) throws -> Client {
         try .makeForGitHub(
+            httpClient: self.httpClient,
             authorization: .bearer(token),
             logger: self.logger
         )

--- a/Lambdas/GHHooks/EventHandler/HandlerContext.swift
+++ b/Lambdas/GHHooks/EventHandler/HandlerContext.swift
@@ -9,7 +9,7 @@ import Logging
 struct HandlerContext: Sendable {
     let eventName: GHEvent.Kind
     let event: GHEvent
-    let httpClient: HTTPClient = .shared
+    let httpClient: HTTPClient
     let discordClient: any DiscordClient
     let githubClient: Client
     let renderClient: RenderClient
@@ -21,6 +21,7 @@ struct HandlerContext: Sendable {
     init(
         eventName: GHEvent.Kind,
         event: GHEvent,
+        httpClient: HTTPClient,
         discordClient: any DiscordClient,
         githubClient: Client,
         renderClient: RenderClient,
@@ -30,6 +31,7 @@ struct HandlerContext: Sendable {
     ) {
         self.eventName = eventName
         self.event = event
+        self.httpClient = httpClient
         self.discordClient = discordClient
         self.githubClient = githubClient
         self.renderClient = renderClient
@@ -38,6 +40,7 @@ struct HandlerContext: Sendable {
         self.requester = .init(
             eventName: eventName,
             event: event,
+            httpClient: httpClient,
             discordClient: discordClient,
             githubClient: githubClient,
             usersService: usersService,

--- a/Lambdas/GHHooks/EventHandler/Requester.swift
+++ b/Lambdas/GHHooks/EventHandler/Requester.swift
@@ -8,7 +8,7 @@ import Logging
 struct Requester: Sendable {
     let eventName: GHEvent.Kind
     let event: GHEvent
-    let httpClient: HTTPClient = .shared
+    let httpClient: HTTPClient
     let discordClient: any DiscordClient
     let githubClient: Client
     let usersService: any UsersService

--- a/Lambdas/GHHooks/GHHooksHandler.swift
+++ b/Lambdas/GHHooks/GHHooksHandler.swift
@@ -37,9 +37,12 @@ struct GHHooksHandler: LambdaHandler {
         /// bootstrapping the logging system which it appears to not have.
         DiscordGlobalConfiguration.makeLogger = { _ in context.logger }
 
-        self.httpClient = HTTPClient(eventLoopGroupProvider: .shared(context.eventLoop))
+        self.httpClient = HTTPClient(
+            eventLoopGroupProvider: .shared(context.eventLoop),
+            configuration: .forPenny
+        )
 
-        let awsClient = AWSClient(httpClientProvider: .shared(self.httpClient))
+        let awsClient = AWSClient(httpClient: self.httpClient)
         self.secretsRetriever = SecretsRetriever(awsClient: awsClient, logger: logger)
 
         let authenticator = Authenticator(

--- a/Lambdas/GHOAuth/OAuthLambda.swift
+++ b/Lambdas/GHOAuth/OAuthLambda.swift
@@ -38,10 +38,13 @@ struct GHOAuthHandler: LambdaHandler {
     }
 
     init(context: LambdaInitializationContext) async throws {
-        self.client = HTTPClient(eventLoopGroupProvider: .shared(context.eventLoop))
+        self.client = HTTPClient(
+            eventLoopGroupProvider: .shared(context.eventLoop),
+            configuration: .forPenny
+        )
         self.logger = context.logger
 
-        let awsClient = AWSClient(httpClientProvider: .shared(client))
+        let awsClient = AWSClient(httpClient: client)
         self.secretsRetriever = SecretsRetriever(awsClient: awsClient, logger: logger)
 
         let apiBaseURL = try requireEnvVar("API_BASE_URL")

--- a/Lambdas/GitHubAPI/+Client.swift
+++ b/Lambdas/GitHubAPI/+Client.swift
@@ -14,11 +14,7 @@ extension Client {
         )
         let transport = AsyncHTTPClientTransport(
             configuration: .init(
-                client: HTTPClient(
-                    configuration: .init(
-                        decompression: .enabled(limit: .ratio(20))
-                    )
-                ),
+                client: HTTPClient.shared,
                 timeout: timeout
             )
         )

--- a/Lambdas/GitHubAPI/+Client.swift
+++ b/Lambdas/GitHubAPI/+Client.swift
@@ -4,6 +4,7 @@ import struct NIOCore.TimeAmount
 
 extension Client {
     package static func makeForGitHub(
+        httpClient: HTTPClient,
         authorization: AuthorizationHeader,
         timeout: TimeAmount = .seconds(5),
         logger: Logger
@@ -14,7 +15,7 @@ extension Client {
         )
         let transport = AsyncHTTPClientTransport(
             configuration: .init(
-                client: HTTPClient.shared,
+                client: httpClient,
                 timeout: timeout
             )
         )

--- a/Lambdas/Sponsors/SponsorsLambda.swift
+++ b/Lambdas/Sponsors/SponsorsLambda.swift
@@ -32,8 +32,11 @@ struct SponsorsHandler: LambdaHandler {
     }
 
     init(context: LambdaInitializationContext) async throws {
-        self.httpClient = HTTPClient(eventLoopGroupProvider: .shared(context.eventLoop))
-        self.awsClient = AWSClient(httpClientProvider: .shared(httpClient))
+        self.httpClient = HTTPClient(
+            eventLoopGroupProvider: .shared(context.eventLoop),
+            configuration: .forPenny
+        )
+        self.awsClient = AWSClient(httpClient: self.httpClient)
         self.secretsRetriever = SecretsRetriever(awsClient: awsClient, logger: context.logger)
         self.logger = context.logger
     }

--- a/Lambdas/Sponsors/SponsorsLambda.swift
+++ b/Lambdas/Sponsors/SponsorsLambda.swift
@@ -13,8 +13,8 @@ struct SponsorsHandler: LambdaHandler {
     typealias Event = APIGatewayV2Request
     typealias Output = APIGatewayV2Response
 
-    let httpClient: HTTPClient = .shared
-    let awsClient: AWSClient = AWSClient()
+    let httpClient: HTTPClient
+    let awsClient: AWSClient
     let secretsRetriever: SecretsRetriever
     let logger: Logger
 
@@ -23,7 +23,7 @@ struct SponsorsHandler: LambdaHandler {
     var discordClient: any DiscordClient {
         get async throws {
             let botToken = try await secretsRetriever.getSecret(arnEnvVarKey: "BOT_TOKEN_ARN")
-            return await DefaultDiscordClient(token: botToken)
+            return await DefaultDiscordClient(httpClient: httpClient, token: botToken)
         }
     }
 
@@ -32,6 +32,8 @@ struct SponsorsHandler: LambdaHandler {
     }
 
     init(context: LambdaInitializationContext) async throws {
+        self.httpClient = HTTPClient(eventLoopGroupProvider: .shared(context.eventLoop))
+        self.awsClient = AWSClient(httpClientProvider: .shared(httpClient))
         self.secretsRetriever = SecretsRetriever(awsClient: awsClient, logger: context.logger)
         self.logger = context.logger
     }
@@ -61,7 +63,10 @@ struct SponsorsHandler: LambdaHandler {
             context.logger.debug("Looking for user in the DB")
             let newSponsorID = payload.sender.id
             let apiBaseURL = try requireEnvVar("API_BASE_URL")
-            let userService = ServiceFactory.makeUsersService(apiBaseURL: apiBaseURL)
+            let userService = ServiceFactory.makeUsersService(
+                httpClient: httpClient,
+                apiBaseURL: apiBaseURL
+            )
             guard let user = try await userService.getUser(githubID: "\(newSponsorID)") else {
                 context.logger.error("No user found with GitHub ID \(newSponsorID)")
                 return APIGatewayV2Response(
@@ -226,10 +231,7 @@ struct SponsorsHandler: LambdaHandler {
         triggerActionRequest.body = .bytes(ByteBuffer(string: #"{"ref":"main"}"#))
         
         // Send request to trigger workflow and read response
-        let githubResponse = try await httpClient.execute(
-            triggerActionRequest,
-            timeout: .seconds(10)
-        )
+        let githubResponse = try await httpClient.execute(triggerActionRequest, timeout: .seconds(10))
         
         guard 200..<300 ~= githubResponse.status.code else {
             let body = try await githubResponse.body.collect(upTo: 1024 * 1024)

--- a/Lambdas/Users/UsersHandler.swift
+++ b/Lambdas/Users/UsersHandler.swift
@@ -1,8 +1,10 @@
 import AWSLambdaRuntime
 import AWSLambdaEvents
+import AsyncHTTPClient
 import Foundation
 import SotoCore
 import Models
+import Shared
 import LambdasShared
 
 @main
@@ -14,9 +16,11 @@ struct UsersHandler: LambdaHandler {
     let logger: Logger
 
     init(context: LambdaInitializationContext) async {
-        let awsClient = AWSClient(
-            httpClientProvider: .createNewWithEventLoopGroup(context.eventLoop)
+        let httpClient = HTTPClient(
+            eventLoopGroupProvider: .shared(context.eventLoop),
+            configuration: .forPenny
         )
+        let awsClient = AWSClient(httpClient: httpClient)
         self.internalService = InternalUsersService(awsClient: awsClient, logger: context.logger)
         self.logger = context.logger
     }

--- a/Lambdas/Users/UsersHandler.swift
+++ b/Lambdas/Users/UsersHandler.swift
@@ -14,10 +14,10 @@ struct UsersHandler: LambdaHandler {
     let logger: Logger
 
     init(context: LambdaInitializationContext) async {
-        self.internalService = InternalUsersService(
-            awsClient: AWSClient(),
-            logger: context.logger
+        let awsClient = AWSClient(
+            httpClientProvider: .createNewWithEventLoopGroup(context.eventLoop)
         )
+        self.internalService = InternalUsersService(awsClient: awsClient, logger: context.logger)
         self.logger = context.logger
     }
     

--- a/Sources/Penny/+Rendering/+LeafRenderer.swift
+++ b/Sources/Penny/+Rendering/+LeafRenderer.swift
@@ -5,10 +5,16 @@ import Logging
 import Foundation
 
 extension LeafRenderer {
-    static func forPenny(logger: Logger) throws -> LeafRenderer {
+    static func forPenny(
+        httpClient: HTTPClient,
+        logger: Logger,
+        on eventLoop: any EventLoop
+    ) throws -> LeafRenderer {
         try LeafRenderer(
             subDirectory: "Penny",
-            logger: logger
+            httpClient: httpClient,
+            logger: logger,
+            on: eventLoop
         )
     }
 }

--- a/Sources/Penny/MainService/MainService.swift
+++ b/Sources/Penny/MainService/MainService.swift
@@ -4,12 +4,14 @@ import AsyncHTTPClient
 import NIOCore
 
 protocol MainService: Sendable {
-    func bootstrapLoggingSystem() async throws
-    func makeBot() async throws -> any GatewayManager
+    func bootstrapLoggingSystem(httpClient: HTTPClient) async throws
+    func makeBot(httpClient: HTTPClient) async throws -> any GatewayManager
     func makeCache(bot: any GatewayManager) async throws -> DiscordCache
     func beforeConnectCall(
         bot: any GatewayManager,
-        cache: DiscordCache
+        cache: DiscordCache,
+        httpClient: HTTPClient,
+        awsClient: AWSClient
     ) async throws -> HandlerContext
     func afterConnectCall(context: HandlerContext) async throws
 }

--- a/Sources/Penny/MainService/PennyService.swift
+++ b/Sources/Penny/MainService/PennyService.swift
@@ -25,7 +25,7 @@ struct PennyService: MainService {
                     message: "I'm Alive! :)",
                     initialNoticeMention: .user(Constants.botDevUserId)
                 ),
-                sendFullLogAsAttachment: .enabled,
+                sendFullLogsAsAttachment: .enabled,
                 mentions: [
                     .warning: .user(Constants.botDevUserId),
                     .error: .user(Constants.botDevUserId),

--- a/Sources/Penny/Penny.swift
+++ b/Sources/Penny/Penny.swift
@@ -9,12 +9,38 @@ struct Penny {
     }
 
     static func start(mainService: any MainService) async throws {
-        try await mainService.bootstrapLoggingSystem()
+        /// Use `1` instead of `System.coreCount`.
+        /// This is preferred for apps that primarily use structured concurrency.
+        let httpClient = HTTPClient(
+            eventLoopGroup: MultiThreadedEventLoopGroup.singleton,
+            configuration: .init(
+                decompression: .enabled(
+                    limit: .size(1 << 30) /// 1 GiB
+                )
+            )
+        )
+        let awsClient = AWSClient(httpClientProvider: .shared(httpClient))
 
-        let bot = try await mainService.makeBot()
+        /// These shutdown calls are only useful for tests where we call `Penny.main()` repeatedly
+        defer {
+            /// Shutdown in reverse order of dependance.
+            try! awsClient.syncShutdown()
+            try! httpClient.syncShutdown()
+        }
+
+        try await mainService.bootstrapLoggingSystem(httpClient: httpClient)
+
+        let bot = try await mainService.makeBot(
+            httpClient: httpClient
+        )
         let cache = try await mainService.makeCache(bot: bot)
 
-        let context = try await mainService.beforeConnectCall(bot: bot, cache: cache)
+        let context = try await mainService.beforeConnectCall(
+            bot: bot,
+            cache: cache,
+            httpClient: httpClient,
+            awsClient: awsClient
+        )
 
         await bot.connect()
 

--- a/Sources/Penny/Penny.swift
+++ b/Sources/Penny/Penny.swift
@@ -1,5 +1,6 @@
 import NIOPosix
 import AsyncHTTPClient
+import Shared
 import SotoS3
 
 @main
@@ -13,13 +14,9 @@ struct Penny {
         /// This is preferred for apps that primarily use structured concurrency.
         let httpClient = HTTPClient(
             eventLoopGroup: MultiThreadedEventLoopGroup.singleton,
-            configuration: .init(
-                decompression: .enabled(
-                    limit: .size(1 << 30) /// 1 GiB
-                )
-            )
+            configuration: .forPenny
         )
-        let awsClient = AWSClient(httpClientProvider: .shared(httpClient))
+        let awsClient = AWSClient(httpClient: httpClient)
 
         /// These shutdown calls are only useful for tests where we call `Penny.main()` repeatedly
         defer {

--- a/Sources/Penny/Penny.swift
+++ b/Sources/Penny/Penny.swift
@@ -42,7 +42,7 @@ struct Penny {
 
         /// These shutdown calls are only useful for tests where we call `Penny.main()` repeatedly
         /// Shutdown in reverse order of dependance.
-        try! await awsClient.shutdown()
-        try! await httpClient.shutdown()
+        try await awsClient.shutdown()
+        try await httpClient.shutdown()
     }
 }

--- a/Sources/Penny/Penny.swift
+++ b/Sources/Penny/Penny.swift
@@ -18,13 +18,6 @@ struct Penny {
         )
         let awsClient = AWSClient(httpClient: httpClient)
 
-        /// These shutdown calls are only useful for tests where we call `Penny.main()` repeatedly
-        defer {
-            /// Shutdown in reverse order of dependance.
-            try! awsClient.syncShutdown()
-            try! httpClient.syncShutdown()
-        }
-
         try await mainService.bootstrapLoggingSystem(httpClient: httpClient)
 
         let bot = try await mainService.makeBot(
@@ -46,5 +39,10 @@ struct Penny {
         for await event in await bot.events {
             EventHandler(event: event, context: context).handle()
         }
+
+        /// These shutdown calls are only useful for tests where we call `Penny.main()` repeatedly
+        /// Shutdown in reverse order of dependance.
+        try! await awsClient.shutdown()
+        try! await httpClient.shutdown()
     }
 }

--- a/Sources/Penny/Services/AutoFaqsService/DefaultAutoFaqsService.swift
+++ b/Sources/Penny/Services/AutoFaqsService/DefaultAutoFaqsService.swift
@@ -49,7 +49,7 @@ actor DefaultAutoFaqsService: AutoFaqsService {
         }
     }
 
-    let httpClient: HTTPClient = .shared
+    var httpClient: HTTPClient!
     var logger = Logger(label: "DefaultAutoFaqsService")
 
     /// Use `getAll()` to retrieve.
@@ -67,7 +67,8 @@ actor DefaultAutoFaqsService: AutoFaqsService {
     let decoder = JSONDecoder()
     let encoder = JSONEncoder()
 
-    init() {
+    init(httpClient: HTTPClient) {
+        self.httpClient = httpClient
         Task {
             await self.setUpResetItemsTask()
             await self.getFreshItemsForCache()

--- a/Sources/Penny/Services/AutoPingsService/DefaultPingsService.swift
+++ b/Sources/Penny/Services/AutoPingsService/DefaultPingsService.swift
@@ -11,7 +11,7 @@ import NIOHTTP1
 
 actor DefaultPingsService: AutoPingsService {
     
-    let httpClient: HTTPClient = .shared
+    let httpClient: HTTPClient
     var logger = Logger(label: "DefaultPingsService")
     
     /// Use `getAll()` to retrieve.
@@ -23,7 +23,8 @@ actor DefaultPingsService: AutoPingsService {
     let decoder = JSONDecoder()
     let encoder = JSONEncoder()
 
-    init() {
+    init(httpClient: HTTPClient) {
+        self.httpClient = httpClient
         Task {
             await self.setUpResetItemsTask()
             await self.getFreshItemsForCache()

--- a/Sources/Penny/Services/EvolutionService/DefaultEvolutionService.swift
+++ b/Sources/Penny/Services/EvolutionService/DefaultEvolutionService.swift
@@ -20,7 +20,7 @@ struct DefaultEvolutionService: EvolutionService {
         }
     }
 
-    let httpClient: HTTPClient = .shared
+    let httpClient: HTTPClient
     let decoder = JSONDecoder()
 
     func list() async throws -> [Proposal] {

--- a/Sources/Penny/Services/FaqsService/DefaultFaqsService.swift
+++ b/Sources/Penny/Services/FaqsService/DefaultFaqsService.swift
@@ -10,7 +10,7 @@ import NIOHTTP1
 
 actor DefaultFaqsService: FaqsService {
 
-    let httpClient: HTTPClient = .shared
+    var httpClient: HTTPClient!
     var logger = Logger(label: "DefaultFaqsService")
 
     /// Use `getAll()` to retrieve.
@@ -23,7 +23,8 @@ actor DefaultFaqsService: FaqsService {
     let decoder = JSONDecoder()
     let encoder = JSONEncoder()
 
-    init() {
+    init(httpClient: HTTPClient) {
+        self.httpClient = httpClient
         Task {
             await self.setUpResetItemsTask()
             await self.getFreshItemsForCache()

--- a/Sources/Penny/Services/StackoverflowService /DefaultSOService.swift
+++ b/Sources/Penny/Services/StackoverflowService /DefaultSOService.swift
@@ -4,7 +4,7 @@ import Logging
 import Foundation
 
 struct DefaultSOService: SOService {
-    let httpClient: HTTPClient = .shared
+    let httpClient: HTTPClient
     let logger = Logger(label: "DefaultSOService")
     let decoder = JSONDecoder()
     private static let urlEncodedAPIKey = Constants.StackOverflow.apiKey

--- a/Sources/Rendering/+LeafRenderer.swift
+++ b/Sources/Rendering/+LeafRenderer.swift
@@ -7,8 +7,10 @@ import Foundation
 extension LeafRenderer {
     package convenience init(
         subDirectory: String,
+        httpClient: HTTPClient,
         extraSources: [any LeafSource] = [],
-        logger: Logger
+        logger: Logger,
+        on eventLoop: any EventLoop
     ) throws {
         let path = "Templates/\(subDirectory)"
         let workingDirectory = FileManager.default.currentDirectoryPath
@@ -23,6 +25,7 @@ extension LeafRenderer {
         )
         let ghSource = GHLeafSource(
             path: path,
+            httpClient: httpClient,
             logger: logger
         )
         let sources = LeafSources()
@@ -37,7 +40,7 @@ extension LeafRenderer {
             configuration: configuration,
             tags: tags,
             sources: sources,
-            eventLoop: HTTPClient.shared.eventLoopGroup.next()
+            eventLoop: eventLoop
         )
     }
 }

--- a/Sources/Rendering/GHLeafSource.swift
+++ b/Sources/Rendering/GHLeafSource.swift
@@ -19,16 +19,18 @@ struct GHLeafSource: LeafSource {
 
     private actor ActorGHLeafSource {
         let path: String
-        let httpClient: HTTPClient = .shared
+        let httpClient: HTTPClient
         let logger: Logger
         let queue = SerialProcessor()
         var cache: [String: ByteBuffer] = [:]
 
         init(
             path: String,
+            httpClient: HTTPClient,
             logger: Logger
         ) {
             self.path = path
+            self.httpClient = httpClient
             self.logger = logger
         }
 
@@ -68,10 +70,12 @@ struct GHLeafSource: LeafSource {
 
     init(
         path: String,
+        httpClient: HTTPClient,
         logger: Logger
     ) {
         self.underlying = .init(
             path: path,
+            httpClient: httpClient,
             logger: logger
         )
     }

--- a/Sources/Shared/+HTTPClient.swift
+++ b/Sources/Shared/+HTTPClient.swift
@@ -1,0 +1,17 @@
+import AsyncHTTPClient
+
+extension HTTPClient.Configuration {
+    package static var forPenny: Self {
+        HTTPClient.Configuration(
+            redirectConfiguration: .follow(max: 5, allowCycles: true),
+            timeout: .init(
+                connect: .seconds(15),
+                read: .seconds(60),
+                write: .seconds(60)
+            ),
+            decompression: .enabled(
+                limit: .ratio(100)
+            )
+        )
+    }
+}

--- a/Sources/Shared/ServiceFactory.swift
+++ b/Sources/Shared/ServiceFactory.swift
@@ -1,7 +1,7 @@
 import AsyncHTTPClient
 
 package enum ServiceFactory {
-    package static func makeUsersService(apiBaseURL: String) -> any UsersService {
-        DefaultUsersService(apiBaseURL: apiBaseURL)
+    package static func makeUsersService(httpClient: HTTPClient, apiBaseURL: String) -> any UsersService {
+        DefaultUsersService(httpClient: httpClient, apiBaseURL: apiBaseURL)
     }
 }

--- a/Sources/Shared/UsersService/DefaultUsersService.swift
+++ b/Sources/Shared/UsersService/DefaultUsersService.swift
@@ -9,14 +9,15 @@ import DiscordModels
 import Models
 
 struct DefaultUsersService: UsersService {
-    let httpClient: HTTPClient = .shared
+    let httpClient: HTTPClient
     let apiBaseURL: String
     let logger = Logger(label: "DefaultUsersService")
 
     let decoder = JSONDecoder()
     let encoder = JSONEncoder()
     
-    init(apiBaseURL: String) {
+    init(httpClient: HTTPClient, apiBaseURL: String) {
+        self.httpClient = httpClient
         self.apiBaseURL = apiBaseURL
     }
 

--- a/Tests/PennyTests/Fake/FakeMainService.swift
+++ b/Tests/PennyTests/Fake/FakeMainService.swift
@@ -38,10 +38,6 @@ actor FakeMainService: MainService {
         )
     }
 
-    deinit {
-        try! httpClient.syncShutdown()
-    }
-
     func bootstrapLoggingSystem(httpClient: HTTPClient) async throws { }
 
     func makeBot(httpClient: HTTPClient) async throws -> any GatewayManager {

--- a/Tests/PennyTests/Fake/FakeMainService.swift
+++ b/Tests/PennyTests/Fake/FakeMainService.swift
@@ -28,7 +28,8 @@ actor FakeMainService: MainService {
             storage: cacheStorage
         )
         self.httpClient = HTTPClient(
-            eventLoopGroup: MultiThreadedEventLoopGroup.singleton
+            eventLoopGroup: MultiThreadedEventLoopGroup.singleton,
+            configuration: .forPenny
         )
         self.context = try Self.makeContext(
             manager: manager,

--- a/Tests/PennyTests/Tests/GHHooksTests.swift
+++ b/Tests/PennyTests/Tests/GHHooksTests.swift
@@ -13,7 +13,9 @@ import NIOPosix
 import XCTest
 
 class GHHooksTests: XCTestCase {
-    let httpClient = HTTPClient.shared
+    let httpClient = HTTPClient(
+        eventLoopGroup: MultiThreadedEventLoopGroup.singleton
+    )
 
     let decoder: JSONDecoder = {
         var decoder = JSONDecoder()
@@ -26,6 +28,10 @@ class GHHooksTests: XCTestCase {
 
     override func setUp() async throws {
         FakeResponseStorage.shared = FakeResponseStorage()
+    }
+
+    override func tearDown() {
+        try! httpClient.syncShutdown()
     }
 
     func testUnicodesPrefix() throws {
@@ -897,6 +903,7 @@ class GHHooksTests: XCTestCase {
         return HandlerContext(
             eventName: eventName,
             event: event,
+            httpClient: httpClient,
             discordClient: FakeDiscordClient(),
             githubClient: Client(
                 serverURL: try Servers.server1(),
@@ -904,6 +911,7 @@ class GHHooksTests: XCTestCase {
             ),
             renderClient: RenderClient(
                 renderer: try .forGHHooks(
+                    httpClient: httpClient,
                     logger: logger
                 )
             ),

--- a/Tests/PennyTests/Tests/GHHooksTests.swift
+++ b/Tests/PennyTests/Tests/GHHooksTests.swift
@@ -31,10 +31,6 @@ class GHHooksTests: XCTestCase {
         FakeResponseStorage.shared = FakeResponseStorage()
     }
 
-    override func tearDown() {
-        try! httpClient.syncShutdown()
-    }
-
     func testUnicodesPrefix() throws {
         do {
             let scalars_16 = "Hello, world! 👍🏾"

--- a/Tests/PennyTests/Tests/GHHooksTests.swift
+++ b/Tests/PennyTests/Tests/GHHooksTests.swift
@@ -14,7 +14,8 @@ import XCTest
 
 class GHHooksTests: XCTestCase {
     let httpClient = HTTPClient(
-        eventLoopGroup: MultiThreadedEventLoopGroup.singleton
+        eventLoopGroup: MultiThreadedEventLoopGroup.singleton,
+        configuration: .forPenny
     )
 
     let decoder: JSONDecoder = {

--- a/Tests/PennyTests/Tests/LeafRenderTests.swift
+++ b/Tests/PennyTests/Tests/LeafRenderTests.swift
@@ -34,8 +34,8 @@ class LeafRenderTests: XCTestCase {
         FakeResponseStorage.shared = FakeResponseStorage()
     }
 
-    override func tearDown() {
-        try! httpClient.syncShutdown()
+    override func tearDown() async throws {
+        try! await httpClient.shutdown()
     }
 
     func testTranslationNeededDescription() async throws {

--- a/Tests/PennyTests/Tests/LeafRenderTests.swift
+++ b/Tests/PennyTests/Tests/LeafRenderTests.swift
@@ -35,7 +35,7 @@ class LeafRenderTests: XCTestCase {
     }
 
     override func tearDown() async throws {
-        try! await httpClient.shutdown()
+        try await httpClient.shutdown()
     }
 
     func testTranslationNeededDescription() async throws {

--- a/Tests/PennyTests/Tests/LeafRenderTests.swift
+++ b/Tests/PennyTests/Tests/LeafRenderTests.swift
@@ -11,7 +11,8 @@ import XCTest
 
 class LeafRenderTests: XCTestCase {
     let httpClient = HTTPClient(
-        eventLoopGroup: MultiThreadedEventLoopGroup.singleton
+        eventLoopGroup: MultiThreadedEventLoopGroup.singleton,
+        configuration: .forPenny
     )
 
     lazy var ghHooksRenderClient = RenderClient(


### PR DESCRIPTION
Revert commits related to using `HTTPClient.shared`.
I don't think using the shared HTTPClient is necessary for Penny. It only moves Penny out of the control of the `HTTPClient`.