### PR TITLE
Test Using arm64

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
   cloudformation-lint:
     name: Check CloudFormation
-    runs-on: ubuntu-latest-arm64
+    runs-on: ubuntu-22.04-arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
   cloudformation-lint:
     name: Check CloudFormation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Nope, not supported.
Same conclusion as the one I came to, a few months ago:
Arm runners are only available as paid runners. Need to create a github-hosted machine with ARM64 arch....