### PR TITLE
Use the official Swift AmazonLinux2023 images + dependency update

### DIFF
--- a/.github/workflows/deploy-all-lambdas.yml
+++ b/.github/workflows/deploy-all-lambdas.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
 
     runs-on: ubuntu-24.04-arm
-    container: amazonlinux:2023
+    container: swift:6.3-amazonlinux2023
 
     env:
       AWS_BUCKET_NAME: penny-lambdas-store
@@ -22,8 +22,8 @@ jobs:
     steps:
       - name: Install AWSCLI v2, Swift, git, jq, zip, tar, zstd, zlib-devel
         run: |
-          dnf install git jq zip tar awscli zstd zlib-devel swiftlang -y
-          swift --version
+          dnf update -y
+          dnf install jq awscli zstd -y
 
       - name: Check out repository
         uses: actions/checkout@v6

--- a/Package.resolved
+++ b/Package.resolved
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattpolzin/OpenAPIKit",
       "state" : {
-        "revision" : "343b2c1793058fcc53c1bd7e2907f8e3a4d640fb",
-        "version" : "3.9.0"
+        "revision" : "c42c0ea6d62f384da4e023ab298b15a79d6899b6",
+        "version" : "6.1.0"
       }
     },
     {
@@ -103,7 +103,7 @@
     {
       "identity" : "swift-algorithms",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-algorithms",
+      "location" : "https://github.com/apple/swift-algorithms.git",
       "state" : {
         "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
         "version" : "1.2.1"
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/swift-aws-lambda-runtime.git",
       "state" : {
-        "revision" : "553b5e3716ef8e922e57b6f271248a808d23d0fb",
-        "version" : "2.8.0"
+        "revision" : "e1e4a15c147920dcdf49c6623766acd0934e1fd8",
+        "version" : "2.9.0"
       }
     },
     {
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates.git",
       "state" : {
-        "revision" : "5aa1c0d1bc204908df47c2075bdbb39573d05e8d",
-        "version" : "1.19.0"
+        "revision" : "bde8ca32a096825dfce37467137c903418c1893d",
+        "version" : "1.19.1"
       }
     },
     {
@@ -177,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-cmark.git",
       "state" : {
-        "revision" : "5d9bdaa4228b381639fff09403e39a04926e2dbe",
-        "version" : "0.7.1"
+        "revision" : "924936d0427cb25a61169739a7660230bffa6ea6",
+        "version" : "0.8.0"
       }
     },
     {
@@ -186,8 +186,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
-        "version" : "1.4.1"
+        "revision" : "03cc312c2c933ed87abace34044a5dff7a3117c1",
+        "version" : "1.5.0"
       }
     },
     {
@@ -339,8 +339,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-openapi-generator.git",
       "state" : {
-        "revision" : "83e8301d6d62c423f8e11d6fcb0c8276d4dbb032",
-        "version" : "1.12.0"
+        "revision" : "5dd0da1c7da7bac8f0c458a02a76f69031137a80",
+        "version" : "1.12.1"
       }
     },
     {


### PR DESCRIPTION
Not 100% sure the CI will work rightaway, but did try the package availabilities locally to see what packages we still need to install via dnf.

I'll have to fix the CI directly on main if it doesn't go well. I think it should be good though, or only require minimal changes.