### PR TITLE
Implement Spam-guard

### DIFF
--- a/Sources/Penny/+Duration.swift
+++ b/Sources/Penny/+Duration.swift
@@ -1,0 +1,12 @@
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+extension Duration {
+    var asTimeInterval: TimeInterval {
+        let (seconds, attoseconds) = self.components
+        return Double(seconds) + (Double(attoseconds) / 1e18)
+    }
+}

--- a/Sources/Penny/Constants.swift
+++ b/Sources/Penny/Constants.swift
@@ -166,6 +166,10 @@ enum Constants {
             .core,
         ]
 
+        static let elevatedPublicCommandsAccessSet: Set<RoleSnowflake> = Set(
+            Roles.elevatedPublicCommandsAccess.map(\.rawValue)
+        )
+
         static let elevatedRestrictedCommandsAccess: [Roles] = [
             .contributor,
             .maintainer,

--- a/Sources/Penny/HandlerContext.swift
+++ b/Sources/Penny/HandlerContext.swift
@@ -19,6 +19,7 @@ final class HandlerContext: Sendable {
     let soChecker: SOChecker
     let swiftReleasesChecker: SwiftReleasesChecker
     let reactionCache: ReactionCache
+    let spamCache: SpamCache<ContinuousClock>
 
     init(
         backgroundProcessor: BackgroundProcessor,
@@ -32,7 +33,8 @@ final class HandlerContext: Sendable {
         evolutionChecker: EvolutionChecker,
         soChecker: SOChecker,
         swiftReleasesChecker: SwiftReleasesChecker,
-        reactionCache: ReactionCache
+        reactionCache: ReactionCache,
+        spamCache: SpamCache<ContinuousClock>
     ) {
         self.backgroundProcessor = backgroundProcessor
         self.usersService = usersService
@@ -46,5 +48,6 @@ final class HandlerContext: Sendable {
         self.soChecker = soChecker
         self.swiftReleasesChecker = swiftReleasesChecker
         self.reactionCache = reactionCache
+        self.spamCache = spamCache
     }
 }

--- a/Sources/Penny/Handlers/EventHandler.swift
+++ b/Sources/Penny/Handlers/EventHandler.swift
@@ -20,6 +20,7 @@ struct EventHandler: GatewayEventHandler {
     }
 
     func onMessageCreate(_ message: Gateway.MessageCreate) async {
+        await SpamHandler(event: message, context: context).handle()
         await MessageHandler(event: message, context: context).handle()
     }
 

--- a/Sources/Penny/Handlers/SpamHandler/SpamCache.swift
+++ b/Sources/Penny/Handlers/SpamHandler/SpamCache.swift
@@ -1,0 +1,116 @@
+import Algorithms
+import DiscordBM
+import Shared
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+/// Cache for detecting users who spam multiple channels at once.
+actor SpamCache<ClockType: Clock> where ClockType.Instant.Duration == Swift.Duration {
+
+    /// Only what is needed to detect the spam and to find the messages back in the Discord cache.
+    struct Entry: Sendable {
+        let messageId: MessageSnowflake
+        let channelId: ChannelSnowflake
+        let timestamp: ClockType.Instant
+
+        init(message: Gateway.MessageCreate, now: ClockType.Instant) {
+            self.messageId = message.id
+            self.channelId = message.channel_id
+            let lag = Duration.seconds(Date.now.timeIntervalSince(message.timestamp.date))
+            self.timestamp = now.advanced(by: .zero - lag)
+        }
+    }
+
+    enum Verdict: Sendable {
+        case notSpam
+        case spam(entries: [Entry])
+        case alreadyFlagged
+    }
+
+    /// How far back a message is taken into account.
+    static var window: Duration { .seconds(20) }
+    /// How many distinct channels a user must post in, in a `window`, to be considered a spammer.
+    static var channelThreshold: Int { 3 }
+    /// Messages that arrive in this period after a flag are removed without reporting again.
+    static var flagDuration: Duration { .seconds(60) }
+
+    private let clock: ClockType
+    private var entries: [UserSnowflake: [Entry]] = [:]
+    private var flagged: [UserSnowflake: ClockType.Instant] = [:]
+
+    init(clock: ClockType, runCleanupBackgroundTask: @escaping (@escaping @Sendable () async -> Void) -> Void) {
+        self.clock = clock
+        runCleanupBackgroundTask {
+            await self.cleanupPeriodically()
+        }
+    }
+
+    func recordAndCheck(
+        _ message: Gateway.MessageCreate,
+        of userId: UserSnowflake
+    ) -> Verdict {
+        let now = self.clock.now
+
+        if let flaggedAt = self.flagged[userId],
+            flaggedAt.duration(to: now) <= Self.flagDuration
+        {
+            return .alreadyFlagged
+        }
+
+        let newEntry = Entry(message: message, now: now)
+
+        var recentMessages = self.entries.removeValue(forKey: userId) ?? []
+
+        /// Messages don't necessarily arrive in the order they were sent, since we handle events concurrently.
+        let highestTimestamp = max(
+            newEntry.timestamp,
+            recentMessages.lazy.map(\.timestamp).max() ?? newEntry.timestamp
+        )
+        recentMessages.removeAll { entry in
+            entry.timestamp.duration(to: highestTimestamp) > Self.window
+        }
+
+        if let index = recentMessages.firstIndex(where: { $0.channelId == newEntry.channelId }) {
+            /// Only 1 entry per channel is kept, and it must be the newest one of that channel
+            /// even if it was not the last one to arrive.
+            if recentMessages[index].timestamp < newEntry.timestamp {
+                recentMessages[index] = newEntry
+            }
+        } else {
+            recentMessages.append(newEntry)
+        }
+
+        assert(recentMessages.lazy.uniqued(on: \.channelId).count == recentMessages.count)
+
+        if recentMessages.count < Self.channelThreshold {
+            self.entries[userId] = recentMessages
+            return .notSpam
+        } else {
+            self.flagged[userId] = now
+            return .spam(entries: recentMessages)
+        }
+    }
+
+    private func cleanupPeriodically() async {
+        while true {
+            guard (try? await Task.sleep(for: .seconds(10), clock: self.clock)) != nil else { return }
+            self.cleanup()
+        }
+    }
+
+    private func cleanup() {
+        let now = self.clock.now
+        self.entries = self.entries.compactMapValues { values in
+            let shouldKeep = values.contains { $0.timestamp.duration(to: now) <= Self.window }
+            return shouldKeep ? values : nil
+        }
+
+        self.flagged = self.flagged.filter { _, value in
+            value.duration(to: now) <= Self.flagDuration
+        }
+    }
+}

--- a/Sources/Penny/Handlers/SpamHandler/SpamHandler.swift
+++ b/Sources/Penny/Handlers/SpamHandler/SpamHandler.swift
@@ -1,0 +1,169 @@
+import DiscordBM
+import Logging
+import NIOCore
+import NIOFoundationEssentialsCompat
+import OrderedCollections
+import Shared
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+struct SpamHandler {
+
+    static let timeoutDuration: Duration = .seconds(60 * 60 * 6)
+    static let reason = "Suspicious activity: writing to multiple channels at once"
+
+    let event: Gateway.MessageCreate
+    let context: HandlerContext
+    var discordService: DiscordService {
+        context.discordService
+    }
+    var logger = Logger(label: "SpamHandler")
+
+    init(event: Gateway.MessageCreate, context: HandlerContext) {
+        self.event = event
+        self.context = context
+        self.logger[metadataKey: "event"] = "\(event)"
+    }
+
+    func handle() async {
+        guard let author = event.author,
+            author.bot != true,
+            author.id != Constants.botId,
+            event.guild_id == Constants.vaporGuildId
+        else { return }
+
+        for role in event.member?.roles ?? [] {
+            if Constants.Roles.elevatedPublicCommandsAccessSet.contains(role) {
+                return
+            }
+        }
+
+        switch await context.spamCache.recordAndCheck(event, of: author.id) {
+        case .notSpam:
+            return
+        case .alreadyFlagged:
+            await discordService.deleteMessage(
+                messageId: event.id,
+                channelId: event.channel_id,
+                reason: Self.reason
+            )
+        case .spam(let entries):
+            await discordService.timeoutMember(
+                userId: author.id,
+                for: Self.timeoutDuration,
+                reason: Self.reason
+            )
+            let messagesWindow = SpamCache<ContinuousClock>.window + .seconds(5)
+            let cachedMessages = await discordService.getCachedMessages(of: author.id, in: messagesWindow)
+            await discordService.sendMessage(
+                channelId: Constants.Channels.modLogs.id,
+                payload: self.makeMessagePayload(
+                    spamEntries: entries,
+                    messages: cachedMessages,
+                    lastMessage: event,
+                    author: author
+                )
+            )
+            await self.removeMessages(of: entries, and: cachedMessages)
+        }
+    }
+
+    /// The `entries` are what was detected, while the `messages` are only what the Discord cache
+    /// happened to have. The cache is populated concurrently with this handler being called, so it
+    /// can be missing the very messages that triggered the detection.
+    private func removeMessages(
+        of entries: [SpamCache<ContinuousClock>.Entry],
+        and messages: [Gateway.MessageCreate]
+    ) async {
+        var removed = Set<MessageSnowflake>(minimumCapacity: entries.count + messages.count)
+        for entry in entries where removed.insert(entry.messageId).inserted {
+            await discordService.deleteMessage(
+                messageId: entry.messageId,
+                channelId: entry.channelId,
+                reason: Self.reason
+            )
+        }
+        for message in messages where removed.insert(message.id).inserted {
+            await discordService.deleteMessage(
+                messageId: message.id,
+                channelId: message.channel_id,
+                reason: Self.reason
+            )
+        }
+    }
+
+    func makeMessagePayload(
+        spamEntries entries: [SpamCache<ContinuousClock>.Entry],
+        messages: [Gateway.MessageCreate],
+        lastMessage: Gateway.MessageCreate,
+        author: DiscordUser
+    ) -> Payloads.CreateMessage {
+        let member = lastMessage.member
+        let avatarURL = member?.uiAvatarURL ?? author.uiAvatarURL
+        let channels = OrderedSet(entries.map(\.channelId))
+        let attachmentName = "spam_messages_\(lastMessage.id.rawValue)"
+        let encoder = JSONEncoder()
+        let jsonData = (try? encoder.encode(messages)) ?? Data()
+
+        return .init(
+            embeds: [
+                .init(
+                    title: "Spam messages detected",
+                    description:
+                        DiscordUtils
+                        .escapingSpecialCharacters(lastMessage.content)
+                        .unicodesPrefix(2_048)
+                        .quotedMarkdown(),
+                    timestamp: lastMessage.timestamp.date,
+                    color: .red,
+                    footer: .init(
+                        text: "From \(member?.uiName ?? author.uiName)",
+                        icon_url: avatarURL.map { .exact($0) }
+                    ),
+                    fields: [
+                        .init(
+                            name: "Author",
+                            value: DiscordUtils.mention(id: author.id),
+                            inline: true
+                        ),
+                        .init(
+                            name: "Username",
+                            value: author.username,
+                            inline: true
+                        ),
+                        .init(
+                            name: "Count",
+                            value: "\(entries.count)",
+                            inline: true
+                        ),
+                        .init(
+                            name: "Timeout Duration",
+                            value: "\(Self.timeoutDuration)",
+                            inline: true
+                        ),
+                        .init(
+                            name: "Channels",
+                            value: channels.map(DiscordUtils.mention(id:)).joined(separator: ", ").unicodesPrefix(1024)
+                        ),
+                    ]
+                )
+            ],
+            files: [
+                .init(
+                    data: ByteBuffer(data: jsonData),
+                    filename: attachmentName
+                )
+            ],
+            attachments: [
+                .init(
+                    index: 0,
+                    filename: attachmentName
+                )
+            ]
+        )
+    }
+}

--- a/Sources/Penny/MainService/PennyService.swift
+++ b/Sources/Penny/MainService/PennyService.swift
@@ -134,6 +134,10 @@ struct PennyService: MainService {
             discordService: discordService
         )
         let reactionCache = ReactionCache()
+        let spamCache = SpamCache(
+            clock: ContinuousClock(),
+            runCleanupBackgroundTask: { task in backgroundProcessor.process(task) }
+        )
         let cachesService = DefaultCachesService(
             awsClient: awsClient,
             context: .init(
@@ -163,7 +167,8 @@ struct PennyService: MainService {
             evolutionChecker: evolutionChecker,
             soChecker: soChecker,
             swiftReleasesChecker: swiftReleasesChecker,
-            reactionCache: reactionCache
+            reactionCache: reactionCache,
+            spamCache: spamCache
         )
         context.botStateManager = BotStateManager(context: context)
         context.discordEventListener = DiscordEventListener(bot: bot, context: context)

--- a/Sources/Penny/Services/DiscordService/DiscordService.swift
+++ b/Sources/Penny/Services/DiscordService/DiscordService.swift
@@ -3,6 +3,12 @@ import Logging
 import OrderedCollections
 import Shared
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
 actor DiscordService {
 
     enum Error: Swift.Error {
@@ -269,6 +275,60 @@ actor DiscordService {
         }
     }
 
+    func deleteMessage(
+        messageId: MessageSnowflake,
+        channelId: ChannelSnowflake,
+        reason: String
+    ) async {
+        do {
+            try await discordClient.deleteMessage(
+                channelId: channelId,
+                messageId: messageId,
+                reason: reason
+            ).guardSuccess()
+        } catch {
+            logger.report(
+                "Couldn't delete a message",
+                error: error,
+                metadata: [
+                    "messageId": .stringConvertible(messageId),
+                    "channelId": .stringConvertible(channelId),
+                    "reason": .string(reason),
+                ]
+            )
+        }
+    }
+
+    /// Times the member out, so they can't send messages or react for the specified duration.
+    func timeoutMember(
+        userId: UserSnowflake,
+        for duration: Duration,
+        reason: String
+    ) async {
+        do {
+            try await discordClient.updateGuildMember(
+                guildId: Constants.vaporGuildId,
+                userId: userId,
+                reason: reason,
+                payload: .init(
+                    communication_disabled_until: .init(
+                        date: Date(timeIntervalSinceNow: duration.asTimeInterval)
+                    )
+                )
+            ).guardSuccess()
+        } catch {
+            logger.report(
+                "Couldn't time a member out",
+                error: error,
+                metadata: [
+                    "userId": .stringConvertible(userId),
+                    "duration": .stringConvertible(duration),
+                    "reason": .string(reason),
+                ]
+            )
+        }
+    }
+
     /// Returns whether or not the response has been successfully sent.
     @discardableResult
     func respondToInteraction(
@@ -354,6 +414,19 @@ actor DiscordService {
             return nil
         }
         return messages
+    }
+
+    func getCachedMessages(
+        of userId: UserSnowflake,
+        in window: Duration
+    ) async -> [Gateway.MessageCreate] {
+        let now = Date.now
+        return await cache.messages.flatMap { (channelId, messages) in
+            messages.filter { message in
+                guard message.author?.id == userId else { return false }
+                return message.timestamp.date.distance(to: now) <= window.asTimeInterval
+            }
+        }
     }
 
     func getChannelMessage(
@@ -448,9 +521,9 @@ actor DiscordService {
     }
 
     func memberHasRolesForElevatedPublicCommandsAccess(member: Guild.Member) -> Bool {
-        Constants.Roles.elevatedPublicCommandsAccess.contains(where: {
-            member.roles.contains($0.rawValue)
-        })
+        !Set(member.roles)
+            .intersection(Constants.Roles.elevatedPublicCommandsAccessSet)
+            .isEmpty
     }
 
     func memberHasRolesForElevatedRestrictedCommandsAccess(member: Guild.Member) -> Bool {

--- a/Tests/PennyTests/Fake/FakeMainService.swift
+++ b/Tests/PennyTests/Fake/FakeMainService.swift
@@ -119,6 +119,10 @@ actor FakeMainService: MainService {
             discordService: discordService
         )
         let reactionCache = ReactionCache()
+        let spamCache = SpamCache(
+            clock: ContinuousClock(),
+            runCleanupBackgroundTask: { _ in }
+        )
         let autoFaqsService = FakeAutoFaqsService()
 
         let context = HandlerContext(
@@ -147,7 +151,8 @@ actor FakeMainService: MainService {
             evolutionChecker: evolutionChecker,
             soChecker: soChecker,
             swiftReleasesChecker: swiftReleasesChecker,
-            reactionCache: reactionCache
+            reactionCache: reactionCache,
+            spamCache: spamCache
         )
         context.botStateManager = BotStateManager(
             context: context,

--- a/Tests/PennyTests/Fake/ManualClock.swift
+++ b/Tests/PennyTests/Fake/ManualClock.swift
@@ -1,0 +1,205 @@
+import NIOConcurrencyHelpers
+
+// source: https://github.com/MahdiBM/swift-dns/blob/main/Tests/DNSClientTests/ManualClock.swift
+
+struct ManualClock: Clock {
+    struct Instant: InstantProtocol, CustomStringConvertible {
+        internal let rawValue: Duration
+
+        internal init(_ rawValue: Duration) {
+            self.rawValue = rawValue
+        }
+
+        static func < (lhs: ManualClock.Instant, rhs: ManualClock.Instant) -> Bool {
+            lhs.rawValue < rhs.rawValue
+        }
+
+        func advanced(by duration: Duration) -> ManualClock.Instant {
+            .init(rawValue + duration)
+        }
+
+        func duration(to other: ManualClock.Instant) -> Duration {
+            other.rawValue - rawValue
+        }
+
+        var description: String {
+            "\(rawValue)"
+        }
+    }
+
+    fileprivate struct Wakeup {
+        let generation: Int
+        let continuation: UnsafeContinuation<Void, any Error>
+        let deadline: Instant
+    }
+
+    fileprivate enum Scheduled: Hashable, Comparable, CustomStringConvertible {
+        case cancelled(Int)
+        case wakeup(Wakeup)
+
+        func hash(into hasher: inout Hasher) {
+            switch self {
+            case .cancelled(let generation):
+                hasher.combine(generation)
+            case .wakeup(let wakeup):
+                hasher.combine(wakeup.generation)
+            }
+        }
+
+        var description: String {
+            switch self {
+            case .cancelled: return "Cancelled wakeup"
+            case .wakeup(let wakeup): return "Wakeup at \(wakeup.deadline)"
+            }
+        }
+
+        static func == (_ lhs: Scheduled, _ rhs: Scheduled) -> Bool {
+            switch (lhs, rhs) {
+            case (.cancelled(let lhsGen), .cancelled(let rhsGen)):
+                return lhsGen == rhsGen
+            case (.cancelled(let lhsGen), .wakeup(let rhs)):
+                return lhsGen == rhs.generation
+            case (.wakeup(let lhs), .cancelled(let rhsGen)):
+                return lhs.generation == rhsGen
+            case (.wakeup(let lhs), .wakeup(let rhs)):
+                return lhs.generation == rhs.generation
+            }
+        }
+
+        static func < (lhs: ManualClock.Scheduled, rhs: ManualClock.Scheduled) -> Bool {
+            switch (lhs, rhs) {
+            case (.cancelled(let lhsGen), .cancelled(let rhsGen)):
+                return lhsGen < rhsGen
+            case (.cancelled(let lhsGen), .wakeup(let rhs)):
+                return lhsGen < rhs.generation
+            case (.wakeup(let lhs), .cancelled(let rhsGen)):
+                return lhs.generation < rhsGen
+            case (.wakeup(let lhs), .wakeup(let rhs)):
+                return lhs.generation < rhs.generation
+            }
+        }
+
+        var deadline: Instant? {
+            switch self {
+            case .cancelled: return nil
+            case .wakeup(let wakeup): return wakeup.deadline
+            }
+        }
+
+        func resume() {
+            switch self {
+            case .wakeup(let wakeup):
+                wakeup.continuation.resume()
+            default:
+                break
+            }
+        }
+    }
+
+    fileprivate struct State {
+        var generation = 0
+        var scheduled = Set<Scheduled>()
+        var now = Instant(.zero)
+        var hasSleepers = false
+    }
+
+    fileprivate let state = NIOLockedValueBox(State())
+
+    var now: Instant {
+        state.withLockedValue { $0.now }
+    }
+
+    var minimumResolution: Duration { .zero }
+
+    init() {}
+
+    fileprivate func cancel(_ generation: Int) {
+        state.withLockedValue { state -> UnsafeContinuation<Void, any Error>? in
+            guard let existing = state.scheduled.remove(.cancelled(generation)) else {
+                // insert the cancelled state for when it comes in to be scheduled as a wakeup
+                state.scheduled.insert(.cancelled(generation))
+                return nil
+            }
+            switch existing {
+            case .wakeup(let wakeup):
+                return wakeup.continuation
+            default:
+                return nil
+            }
+        }?.resume(throwing: CancellationError())
+    }
+
+    var hasSleepers: Bool {
+        state.withLockedValue { $0.hasSleepers }
+    }
+
+    func advance(by duration: Duration) {
+        let pending = state.withLockedValue { state -> Set<Scheduled> in
+            state.now = state.now.advanced(by: duration)
+            let pending = state.scheduled.filter { item in
+                guard let deadline = item.deadline else {
+                    return false
+                }
+                return deadline <= state.now
+            }
+            state.scheduled.subtract(pending)
+            if pending.count > 0 {
+                state.hasSleepers = false
+            }
+            return pending
+        }
+        for item in pending.sorted() {
+            item.resume()
+        }
+    }
+
+    fileprivate func schedule(
+        _ generation: Int,
+        continuation: UnsafeContinuation<Void, any Error>,
+        deadline: Instant
+    ) {
+        let resumption = state.withLockedValue {
+            state -> (UnsafeContinuation<Void, any Error>, Result<Void, any Error>)? in
+            let wakeup = Wakeup(
+                generation: generation,
+                continuation: continuation,
+                deadline: deadline
+            )
+            guard let existing = state.scheduled.remove(.wakeup(wakeup)) else {
+                // there is no cancelled placeholder so let it run free
+                guard deadline > state.now else {
+                    // the deadline is now or in the past so run it immediately
+                    return (continuation, .success(()))
+                }
+                // the deadline is in the future so run it then
+                state.hasSleepers = true
+                state.scheduled.insert(.wakeup(wakeup))
+                return nil
+            }
+            switch existing {
+            case .wakeup:
+                fatalError()
+            case .cancelled:
+                // dont bother adding it back because it has been cancelled before we got here
+                return (continuation, .failure(CancellationError()))
+            }
+        }
+        if let resumption = resumption {
+            resumption.0.resume(with: resumption.1)
+        }
+    }
+
+    func sleep(until deadline: Instant, tolerance: Duration? = nil) async throws {
+        let generation = state.withLockedValue { state -> Int in
+            defer { state.generation += 1 }
+            return state.generation
+        }
+        try await withTaskCancellationHandler {
+            try await withUnsafeThrowingContinuation { continuation in
+                schedule(generation, continuation: continuation, deadline: deadline)
+            }
+        } onCancel: {
+            cancel(generation)
+        }
+    }
+}

--- a/Tests/PennyTests/Fake/TestData.swift
+++ b/Tests/PennyTests/Fake/TestData.swift
@@ -85,6 +85,29 @@ enum TestData {
         return decoded
     }
 
+    /// A message by a user with no roles at all, based on the `thanksMessage` event.
+    static func rolelessMessage(
+        id: MessageSnowflake,
+        channelId: ChannelSnowflake,
+        authorId: UserSnowflake,
+        content: String,
+        timestamp: Date
+    ) -> Gateway.MessageCreate {
+        guard case let .messageCreate(base) = decodedFor(gatewayEventKey: "thanksMessage").data else {
+            fatalError("The 'thanksMessage' event is not a message-create event anymore")
+        }
+        var message = base
+        message.id = id
+        message.channel_id = channelId
+        message.content = content
+        message.timestamp = .init(date: timestamp)
+        message.mentions = []
+        message.author?.id = authorId
+        message.author?.username = "Spammer"
+        message.member?.roles = []
+        return message
+    }
+
     private static let ghHooksEvents: [String: Data] = {
         let data = resource(named: "ghHooksEvents.json")
         let object = try! JSONSerialization.jsonObject(with: data, options: [])

--- a/Tests/PennyTests/Tests/GatewayProcessingTests.swift
+++ b/Tests/PennyTests/Tests/GatewayProcessingTests.swift
@@ -128,6 +128,60 @@ final class GatewayProcessingTests: Sendable {
     }
 
     @Test
+    func spamHandler() async throws {
+        let spammer: UserSnowflake = "1032312357818151033"
+        let messages: [(id: MessageSnowflake, channelId: ChannelSnowflake)] = [
+            ("1039637770005717040", "519613337638797315"),
+            ("1039637770005717041", "684159753189982218"),
+            ("1039637770005717042", "1018169583619821619"),
+        ]
+
+        for message in messages {
+            var event = TestData.decodedFor(gatewayEventKey: "thanksMessage")
+            event.data = .messageCreate(
+                TestData.rolelessMessage(
+                    id: message.id,
+                    channelId: message.channelId,
+                    authorId: spammer,
+                    content: "free nitro at https://example.com",
+                    timestamp: Date()
+                )
+            )
+            await manager.send(event: event)
+        }
+
+        let timeout = try #require(
+            await responseStorage.awaitResponse(
+                at: .updateGuildMember(guildId: Constants.vaporGuildId, userId: spammer)
+            ).value as? Payloads.ModifyGuildMember
+        )
+        let disabledUntil = try #require(timeout.communication_disabled_until?.date)
+        #expect(disabledUntil.timeIntervalSinceNow > SpamHandler.timeoutDuration.asTimeInterval - 60)
+        #expect(disabledUntil.timeIntervalSinceNow <= SpamHandler.timeoutDuration.asTimeInterval)
+
+        let report = try #require(
+            await responseStorage.awaitResponse(
+                at: .createMessage(channelId: Constants.Channels.modLogs.id)
+            ).value as? Payloads.CreateMessage
+        )
+        let embed = try #require(report.embeds?.first)
+        #expect(embed.title == "Spam messages detected")
+        #expect(embed.fields?.first(where: { $0.name == "Count" })?.value == "\(messages.count)")
+        /// The events are handled concurrently so the channels can be in any order.
+        let channelsField = embed.fields?.first(where: { $0.name == "Channels" })
+        #expect(
+            channelsField?.value.split(separator: ", ").sorted()
+                == messages.map({ "<#\($0.channelId.rawValue)>"[...] }).sorted()
+        )
+
+        for message in messages {
+            _ = await responseStorage.awaitResponse(
+                at: .deleteMessage(channelId: message.channelId, messageId: message.id)
+            )
+        }
+    }
+
+    @Test
     func reactionHandler() async throws {
         do {
             let response = try await manager.sendAndAwaitResponse(

--- a/Tests/PennyTests/Tests/SpamCacheTests.swift
+++ b/Tests/PennyTests/Tests/SpamCacheTests.swift
@@ -1,0 +1,243 @@
+import DiscordModels
+import Shared
+import Testing
+
+@testable import Penny
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+@Suite
+struct SpamCacheTests {
+
+    private let spammer: UserSnowflake = "1032312357818151033"
+    private let channels: [ChannelSnowflake] = [
+        "519613337638797315",
+        "684159753189982218",
+        "1018169583619821619",
+    ]
+
+    private func makeMessage(
+        id: MessageSnowflake,
+        inChannel index: Int,
+        of userId: UserSnowflake,
+        sentSecondsAgo secondsAgo: Double = 0
+    ) -> Gateway.MessageCreate {
+        TestData.rolelessMessage(
+            id: id,
+            channelId: channels[index],
+            authorId: userId,
+            content: "free nitro at https://example.com",
+            timestamp: Date(timeIntervalSinceNow: -secondsAgo)
+        )
+    }
+
+    @Test
+    func twoChannelsAreNotSpam() async throws {
+        let clock = ManualClock()
+        let cache = SpamCache(clock: clock, runCleanupBackgroundTask: { _ in })
+
+        for index in 0..<2 {
+            let message = makeMessage(id: try .makeFake(), inChannel: index, of: spammer)
+            let verdict = await cache.recordAndCheck(message, of: spammer)
+            #expect(verdict.isNotSpam, "\(verdict)")
+            clock.advance(by: .seconds(5))
+        }
+    }
+
+    @Test
+    func threeChannelsInTheWindowAreSpam() async throws {
+        let clock = ManualClock()
+        let cache = SpamCache(clock: clock, runCleanupBackgroundTask: { _ in })
+        var verdicts = [SpamCache<ManualClock>.Verdict]()
+
+        for index in 0..<3 {
+            let message = makeMessage(id: try .makeFake(), inChannel: index, of: spammer)
+            verdicts.append(await cache.recordAndCheck(message, of: spammer))
+            clock.advance(by: .seconds(5))
+        }
+
+        #expect(verdicts[0].isNotSpam, "\(verdicts[0])")
+        #expect(verdicts[1].isNotSpam, "\(verdicts[1])")
+        guard case let .spam(entries) = verdicts[2] else {
+            Issue.record("Expected the third message to be spam, but got \(verdicts[2])")
+            return
+        }
+        #expect(entries.map(\.channelId) == channels)
+    }
+
+    @Test
+    func threeChannelsOutsideTheWindowAreNotSpam() async throws {
+        let clock = ManualClock()
+        let cache = SpamCache(clock: clock, runCleanupBackgroundTask: { _ in })
+
+        for index in 0..<3 {
+            let message = makeMessage(id: try .makeFake(), inChannel: index, of: spammer)
+            let verdict = await cache.recordAndCheck(message, of: spammer)
+            #expect(verdict.isNotSpam, "\(verdict)")
+            clock.advance(by: .seconds(45))
+        }
+    }
+
+    @Test
+    func twoChannelsThenAMuchLaterThirdChannelIsNotSpam() async throws {
+        let clock = ManualClock()
+        let cache = SpamCache(clock: clock, runCleanupBackgroundTask: { _ in })
+
+        for index in 0..<2 {
+            let message = makeMessage(id: try .makeFake(), inChannel: index, of: spammer)
+            let verdict = await cache.recordAndCheck(message, of: spammer)
+            #expect(verdict.isNotSpam, "\(verdict)")
+            clock.advance(by: .milliseconds(500))
+        }
+
+        clock.advance(by: .seconds(1_000))
+
+        let message = makeMessage(id: try .makeFake(), inChannel: 2, of: spammer)
+        let verdict = await cache.recordAndCheck(message, of: spammer)
+        #expect(verdict.isNotSpam, "\(verdict)")
+    }
+
+    @Test
+    func usersAreTrackedSeparately() async throws {
+        let clock = ManualClock()
+        let cache = SpamCache(clock: clock, runCleanupBackgroundTask: { _ in })
+        let otherSpammer: UserSnowflake = "1032312357818151034"
+        let innocent: UserSnowflake = "1032312357818151035"
+
+        for index in 0..<3 {
+            let spammerVerdict = await cache.recordAndCheck(
+                makeMessage(id: try .makeFake(), inChannel: index, of: spammer),
+                of: spammer
+            )
+            let innocentVerdict = await cache.recordAndCheck(
+                makeMessage(id: try .makeFake(), inChannel: 0, of: innocent),
+                of: innocent
+            )
+            let otherSpammerVerdict = await cache.recordAndCheck(
+                makeMessage(id: try .makeFake(), inChannel: index, of: otherSpammer),
+                of: otherSpammer
+            )
+
+            if index < 2 {
+                #expect(spammerVerdict.isNotSpam, "\(spammerVerdict)")
+                #expect(otherSpammerVerdict.isNotSpam, "\(otherSpammerVerdict)")
+            } else {
+                #expect(!spammerVerdict.isNotSpam, "\(spammerVerdict)")
+                #expect(!otherSpammerVerdict.isNotSpam, "\(otherSpammerVerdict)")
+            }
+            /// The innocent user only ever posts in the same channel, so they are never spam.
+            #expect(innocentVerdict.isNotSpam, "\(innocentVerdict)")
+
+            clock.advance(by: .seconds(5))
+        }
+    }
+
+    /// `DiscordEventListener` handles events concurrently, so a message that was sent earlier
+    /// can be handled after one that was sent later.
+    @Test
+    func outOfOrderMessagesAreStillSpam() async throws {
+        let clock = ManualClock()
+        let cache = SpamCache(clock: clock, runCleanupBackgroundTask: { _ in })
+        var verdicts = [SpamCache<ManualClock>.Verdict]()
+
+        /// Sent 0, 5 and 10 seconds ago, so handled in the reverse order of being sent.
+        for index in 0..<3 {
+            let message = makeMessage(
+                id: try .makeFake(),
+                inChannel: index,
+                of: spammer,
+                sentSecondsAgo: Double(index) * 5
+            )
+            verdicts.append(await cache.recordAndCheck(message, of: spammer))
+        }
+
+        #expect(verdicts[0].isNotSpam, "\(verdicts[0])")
+        #expect(verdicts[1].isNotSpam, "\(verdicts[1])")
+        guard case let .spam(entries) = verdicts[2] else {
+            Issue.record("Expected the third message to be spam, but got \(verdicts[2])")
+            return
+        }
+        #expect(entries.map(\.channelId) == channels)
+    }
+
+    @Test
+    func anOutOfOrderMessageDoesNotReplaceANewerOneOfTheSameChannel() async throws {
+        let clock = ManualClock()
+        let cache = SpamCache(clock: clock, runCleanupBackgroundTask: { _ in })
+        let newest: MessageSnowflake = "1039637770005717099"
+
+        _ = await cache.recordAndCheck(makeMessage(id: newest, inChannel: 0, of: spammer), of: spammer)
+        _ = await cache.recordAndCheck(
+            makeMessage(id: try .makeFake(), inChannel: 0, of: spammer, sentSecondsAgo: 10),
+            of: spammer
+        )
+        _ = await cache.recordAndCheck(makeMessage(id: try .makeFake(), inChannel: 1, of: spammer), of: spammer)
+        let verdict = await cache.recordAndCheck(
+            makeMessage(id: try .makeFake(), inChannel: 2, of: spammer),
+            of: spammer
+        )
+
+        guard case let .spam(entries) = verdict else {
+            Issue.record("Expected the fourth message to be spam, but got \(verdict)")
+            return
+        }
+        #expect(entries.first(where: { $0.channelId == channels[0] })?.messageId == newest)
+    }
+
+    /// Discord replays buffered events all at once after a gateway resume,
+    /// so the clock does not move at all here.
+    @Test
+    func replayedMessagesAreNotSpam() async throws {
+        let clock = ManualClock()
+        let cache = SpamCache(clock: clock, runCleanupBackgroundTask: { _ in })
+
+        for index in 0..<3 {
+            let message = makeMessage(
+                id: try .makeFake(),
+                inChannel: index,
+                of: spammer,
+                sentSecondsAgo: Double(index) * 120
+            )
+            let verdict = await cache.recordAndCheck(message, of: spammer)
+            #expect(verdict.isNotSpam, "\(verdict)")
+        }
+    }
+
+    @Test
+    func messagesInTheGracePeriodAfterAFlagAreAlreadyFlagged() async throws {
+        let clock = ManualClock()
+        let cache = SpamCache(clock: clock, runCleanupBackgroundTask: { _ in })
+
+        for index in 0..<3 {
+            let message = makeMessage(id: try .makeFake(), inChannel: index, of: spammer)
+            _ = await cache.recordAndCheck(message, of: spammer)
+        }
+
+        clock.advance(by: .seconds(1))
+        let message1 = makeMessage(id: try .makeFake(), inChannel: 0, of: spammer)
+        let inGracePeriod = await cache.recordAndCheck(message1, of: spammer)
+        guard case .alreadyFlagged = inGracePeriod else {
+            Issue.record("Expected the message to be already-flagged, but got \(inGracePeriod)")
+            return
+        }
+
+        clock.advance(by: SpamCache<ManualClock>.flagDuration)
+        let message2 = makeMessage(id: try .makeFake(), inChannel: 0, of: spammer)
+        let afterGracePeriod = await cache.recordAndCheck(message2, of: spammer)
+        #expect(afterGracePeriod.isNotSpam, "\(afterGracePeriod)")
+    }
+}
+
+extension SpamCache.Verdict {
+    fileprivate var isNotSpam: Bool {
+        if case .notSpam = self {
+            return true
+        } else {
+            return false
+        }
+    }
+}


### PR DESCRIPTION
Implements guarding the Discord server from being spammed by the same user (multiple messages in a few seconds in multiple channels).

This behavior is very uncommon by an actual human. I don't recall seeing it even once, so yeah...

Deleted all messages of the spammer in the last some-seconds (25 right now) and times them out for 6 hours until a moderator can make a decision. Logs the deleted messages so if they are deleted in mistake, we can at least manually funnel the messages to the author so they can at least repost it.

Almost all users who have any roles are exempt from all this.

Currently doesn't care if messages contain the same content, but we could also check for that in the future.